### PR TITLE
Feature: accept image path squeeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.onnx
 /coverage
 *.profraw
+.DS_Store

--- a/examples/squeeze.rs
+++ b/examples/squeeze.rs
@@ -75,10 +75,17 @@ fn main() {
 }
 
 pub fn load_image() -> ndarray::ArrayBase<ndarray::OwnedRepr<f32>, ndarray::Dim<[usize; 4]>> {
-    let image_buffer: ImageBuffer<Rgb<u8>, Vec<u8>> = image::open(
+    let args: Vec<String> = std::env::args().collect();
+    let image_path = if args.len() == 2 {
+        Path::new(&args[1]).to_path_buf()
+    } else {
         Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("examples/data/images")
-            .join("bald_eagle.jpeg"),
+        .join("examples/data/images")
+        .join("bald_eagle.jpeg")
+    };
+
+    let image_buffer: ImageBuffer<Rgb<u8>, Vec<u8>> = image::open(
+        image_path,
     )
     .unwrap()
     .resize_exact(224 as u32, 224 as u32, FilterType::Nearest)


### PR DESCRIPTION
This allows `cargo run --release --example squeeze -- ./examples/data/images/pelican.jpeg` (the behaviour without specifying a path is unchanged)