### PR TITLE
fix: do not allocate buffers with length below 64

### DIFF
--- a/src/optimisation.rs
+++ b/src/optimisation.rs
@@ -2,7 +2,7 @@ use crate::{
     compiler::compile,
     resource,
     sequencer::sequence,
-    utils::{ceil, dimensions_infos, initializers, len},
+    utils::{buffer_len, ceil, dimensions_infos, initializers},
     Result,
 };
 
@@ -126,7 +126,7 @@ pub fn load(
             input_name.clone(),
             resource::buffer(
                 device,
-                len(input_dims) as _,
+                buffer_len(input_dims) as _,
                 input_name,
                 BufferUsages::STORAGE | BufferUsages::COPY_DST,
             ),
@@ -165,7 +165,7 @@ pub fn load(
                         output.clone(),
                         resource::buffer(
                             device,
-                            len(output_dims) as _,
+                            buffer_len(output_dims) as _,
                             output.as_str(),
                             BufferUsages::STORAGE | BufferUsages::MAP_READ,
                         ),
@@ -175,7 +175,7 @@ pub fn load(
                         output.clone(),
                         resource::buffer(
                             device,
-                            len(output_dims) as _,
+                            buffer_len(output_dims) as _,
                             output.as_str(),
                             BufferUsages::STORAGE,
                         ),

--- a/tests/matrix.rs
+++ b/tests/matrix.rs
@@ -141,7 +141,7 @@ fn test_resize() {
         .expect("session did not create");
     let result = pollster::block_on(session.run(input_data)).unwrap();
 
-    let test_y = vec![1., 3., 0., 0.];
+    let test_y = vec![1., 3.];
     assert_eq!(result["Y"], test_y);
 
     let mut input_data = HashMap::new();

--- a/tests/pretrained_models.rs
+++ b/tests/pretrained_models.rs
@@ -17,7 +17,7 @@ fn test_relu() {
     .expect("session did not create");
     let result = pollster::block_on(session.run(input_data)).unwrap();
 
-    assert_eq!(result["y"], &[0.0, 1.0, 0.0, 0.0]);
+    assert_eq!(result["y"], &[0.0, 1.0]);
 }
 
 #[test]


### PR DESCRIPTION
I was testing wonnx with a very simple mnist model that has a Softmax layer at the end leading to a 1x10 tensor as output. This lead to the error below: a buffer of length 40 was supposed to be allocated (4 bytes for a float32, 10 elements) but 40 bytes is below the minimum length required by wgpu.

This patch ensures that no buffers with length <64 are allocated. Additionally it will slice output buffers to the expected size before returning them. 

Please check the changes to the tests in particular before merging. 

````
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_bind_group
      note: label = `sequential_3/dense_10/Softmax`
    buffer binding size 40 is less than minimum 64
      note: buffer = `sequential_3/dense_10/MatMul_Gemm__43:0`

', /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.11.1/src/backend/direct.rs:2195:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: std::panicking::begin_panic_fmt
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:460:5
   2: wgpu::backend::direct::default_error_handler
             at /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.11.1/src/backend/direct.rs:2195:5
   3: core::ops::function::Fn::call
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/ops/function.rs:70:5
   4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/alloc/src/boxed.rs:1705:9
   5: wgpu::backend::direct::ErrorSinkRaw::handle_error
             at /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.11.1/src/backend/direct.rs:2183:9
   6: wgpu::backend::direct::Context::handle_error
             at /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.11.1/src/backend/direct.rs:184:9
   7: <wgpu::backend::direct::Context as wgpu::Context>::device_create_bind_group
             at /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.11.1/src/backend/direct.rs:1163:13
   8: wgpu::Device::create_bind_group
             at /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.11.1/src/lib.rs:1746:17
   9: wonnx::optimisation::load
             at /Users/tommy/Repos/wonnx/src/optimisation.rs:228:30
  10: wonnx::Session::from_model::{{closure}}
             at /Users/tommy/Repos/wonnx/src/lib.rs:79:39
  11: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/future/mod.rs:80:19
  12: wonnx::Session::from_path::{{closure}}
             at /Users/tommy/Repos/wonnx/src/lib.rs:70:9
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/future/mod.rs:80:19
  14: nnx::run::{{closure}}
             at ./src/main.rs:161:16
  15: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/future/mod.rs:80:19
  16: pollster::block_on
             at /Users/tommy/.cargo/registry/src/github.com-1ecc6299db9ec823/pollster-0.2.4/src/lib.rs:132:15
  17: nnx::main
             at ./src/main.rs:241:2
  18: core::ops::function::FnOnce::call_once
             at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/ops/function.rs:227:5
````