### PR TITLE
feat: implement a very slow softmax

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -101,12 +101,13 @@ pub fn compile(
             1,
         ),
         // Copy data
-        "Reshape" | "Dropout" | "Flatten" | "Squeeze" | "Softmax" => (
+        "Reshape" | "Dropout" | "Flatten" | "Squeeze" => (
             "endomorphism/copy.wgsl".to_string(),
             ceil(output_lengths[0], 16) as _,
             1,
             1,
         ),
+        "Softmax" => ("endomorphism/softmax.wgsl".to_string(), 1, 1, 1),
         // Arithmetic operation
         "Add" | "And" | "Div" | "Equal" | "Greater" | "GreaterOrEqual" | "Less" | "LessOrEqual"
         | "Mod" | "Mul" | "Or" | "Sub" => {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -18,6 +18,7 @@ pub fn compile(
     node: &crate::onnx::NodeProto,
     dims_infos: &HashMap<String, Vec<i64>>,
     tera: &Tera,
+    opset_version: i64,
 ) -> CompiledNode {
     // Escape unwanted characters
     let mut inputs = node.get_input().to_vec();
@@ -90,6 +91,7 @@ pub fn compile(
     context.insert("i_chunks", &input_chunks);
     context.insert("o_chunks", &output_chunks);
     context.insert("op_type", &node.get_op_type());
+    context.insert("opset_version", &opset_version);
 
     let (template, x, y, z) = match node.get_op_type() {
         // Map simple function
@@ -111,6 +113,33 @@ pub fn compile(
         // Arithmetic operation
         "Add" | "And" | "Div" | "Equal" | "Greater" | "GreaterOrEqual" | "Less" | "LessOrEqual"
         | "Mod" | "Mul" | "Or" | "Sub" => {
+            let default_axis = match opset_version {
+                1..=10 => 1,   // https://github.com/onnx/onnx/blob/master/docs/Changelog.md#softmax-1
+                11..=12 => 1, // https://github.com/onnx/onnx/blob/master/docs/Changelog.md#softmax-11
+                13..=15 => -1, // https://github.com/onnx/onnx/blob/master/docs/Changelog.md#softmax-13
+                _ => panic!("unknown opset version: {}", opset_version),
+            };
+
+            /* Describes the axis of the inputs when coerced to 2D; defaults to one because the 0th axis most likely
+            describes the batch_size. From version 13 onwards, counting backwards is also allowed. We only support the
+            variant with [1,n] input tensors, where axis is 1 or -1 */
+            let mut axis = get_attribute("axis", Some(default_axis), node);
+            if axis < 0 {
+                if opset_version >= 13 {
+                    axis += input_dims.len() as i64;
+                } else {
+                    panic!("invalid axis index {}", axis);
+                }
+            }
+
+            if axis >= (input_dims.len() as i64) {
+                panic!("invalid axis index {}", axis);
+            }
+
+            if axis != 1 {
+                unimplemented!("Softmax is only implemented for [1,n] input tensors and on axis 1");
+            }
+
             let coefficient = get_attribute("coefficient", Some(1.0), node);
             context.insert("coefficient", &coefficient);
             context.insert(

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -109,10 +109,7 @@ pub fn compile(
             1,
             1,
         ),
-        "Softmax" => ("endomorphism/softmax.wgsl".to_string(), 1, 1, 1),
-        // Arithmetic operation
-        "Add" | "And" | "Div" | "Equal" | "Greater" | "GreaterOrEqual" | "Less" | "LessOrEqual"
-        | "Mod" | "Mul" | "Or" | "Sub" => {
+        "Softmax" => {
             let default_axis = match opset_version {
                 1..=10 => 1,   // https://github.com/onnx/onnx/blob/master/docs/Changelog.md#softmax-1
                 11..=12 => 1, // https://github.com/onnx/onnx/blob/master/docs/Changelog.md#softmax-11
@@ -140,6 +137,11 @@ pub fn compile(
                 unimplemented!("Softmax is only implemented for [1,n] input tensors and on axis 1");
             }
 
+            ("endomorphism/softmax.wgsl".to_string(), 1, 1, 1)
+        }
+        // Arithmetic operation
+        "Add" | "And" | "Div" | "Equal" | "Greater" | "GreaterOrEqual" | "Less" | "LessOrEqual"
+        | "Mod" | "Mul" | "Or" | "Sub" => {
             let coefficient = get_attribute("coefficient", Some(1.0), node);
             context.insert("coefficient", &coefficient);
             context.insert(

--- a/src/optimisation.rs
+++ b/src/optimisation.rs
@@ -120,7 +120,7 @@ lazy_static! {
 pub fn load(
     graph: &crate::onnx::GraphProto,
     device: &wgpu::Device,
-    _opset_version: i64,
+    opset_version: i64,
 ) -> Result<(HashMap<String, wgpu::Buffer>, Vec<EncoderBuilder>)> {
     let initializers = initializers(graph);
     let dims_info = dimensions_infos(graph);
@@ -157,7 +157,8 @@ pub fn load(
 
         let (current_node, optimisation_length) =
             sequence(&names, nodes, device, &initializers, &mut inner_infos);
-        let CompiledNode { shader, threads } = compile(&current_node, &dims_info, &TEMPLATES);
+        let CompiledNode { shader, threads } =
+            compile(&current_node, &dims_info, &TEMPLATES, opset_version);
         info!("shader: {}", shader);
 
         // Initalialising Output

--- a/src/optimisation.rs
+++ b/src/optimisation.rs
@@ -42,6 +42,11 @@ lazy_static! {
         )
         .unwrap();
         tera.add_raw_template(
+            "endomorphism/softmax.wgsl",
+            include_str!("../templates/endomorphism/softmax.wgsl"),
+        )
+        .unwrap();
+        tera.add_raw_template(
             "endomorphism/map.wgsl",
             include_str!("../templates/endomorphism/map.wgsl"),
         )

--- a/src/optimisation.rs
+++ b/src/optimisation.rs
@@ -120,6 +120,7 @@ lazy_static! {
 pub fn load(
     graph: &crate::onnx::GraphProto,
     device: &wgpu::Device,
+    _opset_version: i64,
 ) -> Result<(HashMap<String, wgpu::Buffer>, Vec<EncoderBuilder>)> {
     let initializers = initializers(graph);
     let dims_info = dimensions_infos(graph);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
+use protobuf::RepeatedField;
+
 use crate::onnx;
+use crate::onnx::OperatorSetIdProto;
 use std::collections::HashMap;
 use std::convert::From;
 use std::convert::Into;
@@ -189,6 +192,10 @@ pub fn graph(
 
 pub fn model(graph: onnx::GraphProto) -> onnx::ModelProto {
     let mut model = crate::onnx::ModelProto::new();
+    let mut onnx_opset_import = OperatorSetIdProto::new();
+    onnx_opset_import.set_domain("".to_string());
+    onnx_opset_import.set_version(13);
+    model.set_opset_import(RepeatedField::from_slice(&[onnx_opset_import]));
     model.set_graph(graph);
     model
 }

--- a/templates/endomorphism/softmax.wgsl
+++ b/templates/endomorphism/softmax.wgsl
@@ -15,6 +15,9 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	{% if op_type == "Softmax" %}
 
 	var max_element: f32 = -9999999.9;
+	// WGSL doesn't have a way to write -Infinity (https://github.com/gpuweb/gpuweb/issues/1769)
+	// Therefore we use log(0.0) instead which returns -Infinity
+	var max_element: f32 = log(0.0);
 	for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
 		let element = {{ inputs[0] }}.data[gidx + k];
 		max_element = max(max_element, element);

--- a/templates/endomorphism/softmax.wgsl
+++ b/templates/endomorphism/softmax.wgsl
@@ -7,14 +7,14 @@ var<storage, read> {{ inputs[0] }}: Array;
 [[group(0), binding(1)]]
 var<storage, write> {{ outputs[0] }}: Array;
 
-
 [[stage(compute), workgroup_size(1)]]
 fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 	let gidx = global_id.x;
 
 	{% if op_type == "Softmax" %}
-
-	var max_element: f32 = -9999999.9;
+	// Softmax = exp(input - max(input)) / sum(exp(input - max(input)))
+	
+	// First, determine max(input)
 	// WGSL doesn't have a way to write -Infinity (https://github.com/gpuweb/gpuweb/issues/1769)
 	// Therefore we use log(0.0) instead which returns -Infinity
 	var max_element: f32 = log(0.0);
@@ -23,12 +23,14 @@ fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
 		max_element = max(max_element, element);
 	}
 
-	 var sum: f32 = 0.0;
-	 for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
+	// Calculate sum(exp(input - max(input)))
+	var sum: f32 = 0.0;
+	for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
 		let element = {{ inputs[0] }}.data[gidx + k];
 		sum  = sum + exp(element - max_element);
 	}
 
+	// Calculate elements and write to output
 	for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
 		let element = {{ inputs[0] }}.data[gidx + k];
 		{{ outputs[0] }}.data[gidx + k] = exp(element - max_element) / sum;

--- a/templates/endomorphism/softmax.wgsl
+++ b/templates/endomorphism/softmax.wgsl
@@ -1,0 +1,34 @@
+
+{%- include "structs.wgsl" -%}
+
+[[group(0), binding(0)]]
+var<storage, read> {{ inputs[0] }}: Array;
+
+[[group(0), binding(1)]]
+var<storage, write> {{ outputs[0] }}: Array;
+
+
+[[stage(compute), workgroup_size(1)]]
+fn main([[builtin(global_invocation_id)]] global_id: vec3<u32>) {
+	let gidx = global_id.x;
+
+	{% if op_type == "Softmax" %}
+
+	var max_element: f32 = -9999999.9;
+	for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
+		let element = {{ inputs[0] }}.data[gidx + k];
+		max_element = max(max_element, element);
+	}
+
+	 var sum: f32 = 0.0;
+	 for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
+		let element = {{ inputs[0] }}.data[gidx + k];
+		sum  = sum + exp(element - max_element);
+	}
+
+	for(var k: u32 = 0u; k < {{ i_lens[0] }}u; k = k + 1u) {
+		let element = {{ inputs[0] }}.data[gidx + k];
+		{{ outputs[0] }}.data[gidx + k] = exp(element - max_element) / sum;
+	}
+	{% endif %}
+}


### PR DESCRIPTION
Currently the Softmax operator just copies data from input to output. To match Keras, I implemented actual Softmax in WGSL. 

This is the first time I have written any WGSL and my suspicion is that this is probably the slowest possible way to implement it (i.e. single thread, fully serial, not running anything in parallel on the GPU at all - main CPU is probably faster at this!). Nevertheless I think it is good to have this at this point (can make it fast later). 

Note, the actual ONNX spec may also require Softmax on a single axis in a matrix, see [here](https://github.com/onnx/onnx/blob/master/onnx/backend/test/case/node/softmax.py). Probably also should write some tests.