### PR TITLE
feat: support Unsqueeze and Identity ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ fn test_matmul_square_matrix() {
 |<a href="#GridSample">GridSample</a>|<a href="Changelog.md#GridSample-16">16</a>|
 |<a href="#HardSigmoid">HardSigmoid</a>|<a href="Changelog.md#HardSigmoid-6">6</a>, <a href="Changelog.md#HardSigmoid-1">1</a>|
 |<a href="#Hardmax">Hardmax</a>|<a href="Changelog.md#Hardmax-13">13</a>, <a href="Changelog.md#Hardmax-11">11</a>, <a href="Changelog.md#Hardmax-1">1</a>|
-|<a href="#Identity">Identity</a>|<a href="Changelog.md#Identity-16">16</a>, <a href="Changelog.md#Identity-14">14</a>, <a href="Changelog.md#Identity-13">13</a>, <a href="Changelog.md#Identity-1">1</a>|
+|<a href="#Identity">Identity</a>|<a href="Changelog.md#Identity-16">16</a>, <a href="Changelog.md#Identity-14">14</a>, <a href="Changelog.md#Identity-13">13</a>, <a href="Changelog.md#Identity-1">1</a>|✅|
 |<a href="#If">If</a>|<a href="Changelog.md#If-16">16</a>, <a href="Changelog.md#If-13">13</a>, <a href="Changelog.md#If-11">11</a>, <a href="Changelog.md#If-1">1</a>|
 |<a href="#InstanceNormalization">InstanceNormalization</a>|<a href="Changelog.md#InstanceNormalization-6">6</a>, <a href="Changelog.md#InstanceNormalization-1">1</a>|
 |<a href="#IsInf">IsInf</a>|<a href="Changelog.md#IsInf-10">10</a>|
@@ -303,7 +303,7 @@ fn test_matmul_square_matrix() {
 |<a href="#Transpose">Transpose</a>|<a href="Changelog.md#Transpose-13">13</a>, <a href="Changelog.md#Transpose-1">1</a>|✅|
 |<a href="#Trilu">Trilu</a>|<a href="Changelog.md#Trilu-14">14</a>|
 |<a href="#Unique">Unique</a>|<a href="Changelog.md#Unique-11">11</a>|
-|<a href="#Unsqueeze">Unsqueeze</a>|<a href="Changelog.md#Unsqueeze-13">13</a>, <a href="Changelog.md#Unsqueeze-11">11</a>, <a href="Changelog.md#Unsqueeze-1">1</a>|
+|<a href="#Unsqueeze">Unsqueeze</a>|<a href="Changelog.md#Unsqueeze-13">13</a>, <a href="Changelog.md#Unsqueeze-11">11</a>, <a href="Changelog.md#Unsqueeze-1">1</a>|✅|
 |<a href="#Upsample">Upsample</a> (deprecated)|<a href="Changelog.md#Upsample-10">10</a>, <a href="Changelog.md#Upsample-9">9</a>, <a href="Changelog.md#Upsample-7">7</a>|
 |<a href="#Where">Where</a>|<a href="Changelog.md#Where-16">16</a>, <a href="Changelog.md#Where-9">9</a>|
 |<a href="#Xor">Xor</a>|<a href="Changelog.md#Xor-7">7</a>, <a href="Changelog.md#Xor-1">1</a>|

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -127,7 +127,7 @@ pub fn compile(
             1,
         ),
         // Copy data
-        "Reshape" | "Dropout" | "Flatten" | "Squeeze" => (
+        "Reshape" | "Dropout" | "Flatten" | "Squeeze" | "Unsqueeze" | "Identity" => (
             "endomorphism/copy.wgsl".to_string(),
             ceil(output_lengths[0], 16) as _,
             1,

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+// use wasm_bindgen_test::*;
+// Indicates a f32 overflow in an intermediate Collatz value
+
+use wonnx::utils::{graph, model, node, tensor};
+
+#[test]
+fn test_identity() {
+    // USER INPUT
+
+    let n: usize = 16;
+    let mut input_data = HashMap::new();
+
+    let data: Vec<f32> = (0..n).map(|x| x as f32).collect();
+    let dims = vec![n as i64];
+    input_data.insert("X".to_string(), data.as_slice());
+
+    // ONNX INPUTS
+    let model = model(graph(
+        vec![tensor("X", &dims)],
+        vec![tensor("Y", &dims)],
+        vec![],
+        vec![],
+        vec![node(vec!["X"], vec!["Y"], "cos", "Identity", vec![])],
+    ));
+
+    // LOGIC
+
+    let session =
+        pollster::block_on(wonnx::Session::from_model(model)).expect("Session did not create");
+
+    let result = pollster::block_on(session.run(input_data)).unwrap();
+    assert_eq!(result["Y"], data);
+}


### PR DESCRIPTION
These ops appear to only change shape (which we don't care about as we require the dimensions to be inferred up front anyway), not data. Squeeze was already there so I added Unsqueeze and Identity as well.

We should probably not bother copying data between buffers but have a step in the compiler that simply aliases buffers, i.e.  in `input_a -> Identity -> SomeOtherOp`, the `SomeOtherOp` should just take `input_a` as input rather than the output from identity (which we then won't generate).