### PR TITLE
feat: Implement GlobalAveragePool op

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ fn test_matmul_square_matrix() {
 |<a href="#GatherElements">GatherElements</a>|<a href="Changelog.md#GatherElements-13">13</a>, <a href="Changelog.md#GatherElements-11">11</a>|
 |<a href="#GatherND">GatherND</a>|<a href="Changelog.md#GatherND-13">13</a>, <a href="Changelog.md#GatherND-12">12</a>, <a href="Changelog.md#GatherND-11">11</a>|
 |<a href="#Gemm">Gemm</a>|<a href="Changelog.md#Gemm-13">13</a>, <a href="Changelog.md#Gemm-11">11</a>, <a href="Changelog.md#Gemm-9">9</a>, <a href="Changelog.md#Gemm-7">7</a>, <a href="Changelog.md#Gemm-6">6</a>, <a href="Changelog.md#Gemm-1">1</a>|✅|
-|<a href="#GlobalAveragePool">GlobalAveragePool</a>|<a href="Changelog.md#GlobalAveragePool-1">1</a>|
+|<a href="#GlobalAveragePool">GlobalAveragePool</a>|<a href="Changelog.md#GlobalAveragePool-1">1</a>|✅|
 |<a href="#GlobalLpPool">GlobalLpPool</a>|<a href="Changelog.md#GlobalLpPool-2">2</a>, <a href="Changelog.md#GlobalLpPool-1">1</a>|
 |<a href="#GlobalMaxPool">GlobalMaxPool</a>|<a href="Changelog.md#GlobalMaxPool-1">1</a>|
 |<a href="#Greater">Greater</a>|<a href="Changelog.md#Greater-13">13</a>, <a href="Changelog.md#Greater-9">9</a>, <a href="Changelog.md#Greater-7">7</a>, <a href="Changelog.md#Greater-1">1</a>|✅|

--- a/tests/globalaveragepool.rs
+++ b/tests/globalaveragepool.rs
@@ -1,0 +1,60 @@
+use approx::assert_ulps_eq;
+use std::collections::HashMap;
+use wonnx::utils::{graph, model, node, tensor};
+
+fn abs_eq_vector(xs: &[f32], ys: &[f32]) {
+    assert_eq!(xs.len(), ys.len());
+    for i in 0..xs.len() {
+        assert_ulps_eq!(xs[i], ys[i], max_ulps = 2);
+    }
+}
+
+#[test]
+fn global_average_pool() {
+    let mut input_data = HashMap::new();
+
+    let batches = 1;
+    let width_height: usize = 2;
+    let channels: usize = 4;
+    // FIXME: we are testing with 4 channels because the AveragePool op doesn't support output tensors with total length non divisible by 4
+    let data: Vec<f32> = (0..(batches * width_height * width_height * channels))
+        .map(|x| x as f32)
+        .collect();
+    let shape = vec![
+        batches as i64,
+        channels as i64,
+        width_height as i64,
+        width_height as i64,
+    ];
+    let output_shape = vec![batches as i64, channels as i64, 1, 1];
+    input_data.insert("X".to_string(), data.as_slice());
+
+    let bn_model = model(graph(
+        vec![tensor("X", &shape)],
+        vec![tensor("Y", &output_shape)],
+        vec![],
+        vec![],
+        vec![node(
+            vec!["X"],
+            vec!["Y"],
+            "gap",
+            "GlobalAveragePool",
+            vec![],
+        )],
+    ));
+
+    // LOGIC
+    let session =
+        pollster::block_on(wonnx::Session::from_model(bn_model)).expect("Session did not create");
+
+    let result = pollster::block_on(session.run(input_data)).unwrap();
+    let out_y = &result["Y"];
+
+    // The GlobalAveragePool op simply averages all pixels in an image (NxCxWxH becomes NxCx1x1). In our test data pixels
+    // range from 0..16, so the test data and output are given as:
+    // Channel 1: [[0,1], [2,3]] => average is 1,5
+    // Channel 2: [[4,5], [6,7]] => average is 5,5
+    // Channel 3: [[8,9], [10, 11]] => average is 9,5
+    // Channel 4: [[12,13], [14, 15]] => average is 13,5
+    abs_eq_vector(out_y.as_slice(), &[1.5, 5.5, 9.5, 13.5]);
+}


### PR DESCRIPTION
GlobalAveragePool is basically a special case of the AveragePool op where kernel_size=image_size. This means that it simply averages all pixels in a channel (e.g. NxCxWxH becomes NxCx1x1).

This implementation just re-uses the AveragePool implementation. This implementation does not appear to work with output tensors with the total element count not divisible by 4 (see #32), but works fine otherwise.