### PR TITLE
feat: honor WGPU_ADAPTER_NAME and WGPU_BACKEND env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ Wonnx aims for running blazing Fast AI on any device.
 git clone https://github.com/haixuanTao/wonnx.git
 ```
 
-- Then with git lfs installed: 
+### From Rust
+
+Ensure Git LFS is initialized and has downloaded the model files (in `wonnx/examples/data/models`). Then to run an example:
 
 ```bash
 cargo run --example squeeze --release
 ```
 
-or with python. 
+### From Python 
 
 ```bash
 pip install wonnx
@@ -75,7 +77,7 @@ python -m onnxsim mnist-8.onnx opt-mnist.onnx
 cargo run --example mnist --release
 ```
 
-## Usage in rust
+## Usage in Rust
 
 ```rust
 fn main() -> HashMap<String, Vec<f32>> {
@@ -100,11 +102,18 @@ fn main() -> HashMap<String, Vec<f32>> {
 > Examples are available in the `examples` folder
 
 
-## Tested Model
+## Tested Models
 
 - Squeezenet
 - MNIST
 
+## GPU selection
+
+You may set the following environment variables to influence GPU selection by WGPU:
+
+* `WGPU_ADAPTER_NAME` with a substring of the name of the adapter you want to use (e.g. `1080` will match `NVIDIA GeForce 1080ti`).
+* `WGPU_BACKEND` with a comma separated list of the backends you want to use (`vulkan`, `metal`, `dx12`, `dx11`, or `gl`).
+* `WGPU_POWER_PREFERENCE` with the power preference to choose when a specific adapter name isn't specified (`high` or `low`)
 
 ## Contribution: On implementing a new Operator
 

--- a/wonnx/src/resource.rs
+++ b/wonnx/src/resource.rs
@@ -1,16 +1,12 @@
 use wgpu::{util::DeviceExt, BufferUsages};
 
-// Get a device and a queue
+// Get a device and a queue, honoring WGPU_ADAPTER_NAME and WGPU_BACKEND environment variables
 pub async fn request_device_queue() -> (wgpu::Device, wgpu::Queue) {
-    // `()` indicates that the macro takes no argument.
-    // The macro will expand into the contents of this block.
-
     let instance = wgpu::Instance::new(wgpu::Backends::all());
-
-    let adapter = instance
-        .request_adapter(&wgpu::RequestAdapterOptionsBase::default())
+    let backends = wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all);
+    let adapter = wgpu::util::initialize_adapter_from_env_or_default(&instance, backends, None)
         .await
-        .expect("No GPU found for referenced preference");
+        .expect("No GPU found given preference");
 
     // `request_device` instantiates the feature specific connection to the GPU, defining some parameters,
     //  `features` being the available features.


### PR DESCRIPTION
Fix #50, it simply uses wgpu's functions to decide a GPU based on env variables.

In the future we should probably also add a way to construct a session with a specific wgpu device if the user wants to select a specific GPU. 